### PR TITLE
Refactor PaymentVoucherController and add destroy method

### DIFF
--- a/app/Http/Controllers/PaymentVoucherController.php
+++ b/app/Http/Controllers/PaymentVoucherController.php
@@ -20,13 +20,11 @@ class PaymentVoucherController extends Controller
     public function create()
     {
         $attr = request()->validate([
-            'payee_company' => 'required|max:255',
             'payee_name' => 'required|max:255',
             'payee_phone' => 'required|numeric',
             'payee_bank' => 'nullable|max:100',
             'payee_acc_no' => 'nullable|max:100',
             'payment_method' => 'nullable',
-            'date' => 'nullable|date',
             'due_date' => 'nullable|date',
             'remarks' => 'nullable',
         ]);
@@ -68,13 +66,11 @@ class PaymentVoucherController extends Controller
         } else {
 
             $attr = request()->validate([
-                'payee_company' => 'required|max:255',
                 'payee_name' => 'required|max:255',
                 'payee_phone' => 'required|numeric',
                 'payee_bank' => 'nullable|max:100',
                 'payee_acc_no' => 'nullable|max:100',
                 'payment_method' => 'nullable',
-                'date' => 'nullable|date',                       
                 'due_date' => 'nullable|date',
                 'remarks' => 'nullable',
             ]);
@@ -86,7 +82,15 @@ class PaymentVoucherController extends Controller
             return redirect('/payment-vouchers/' . $voucher->id)->with('success', 'Baucer dikemaskini.');
         }
     }
-
+public function destroy(PaymentVoucher $voucher)
+{
+    if ($voucher->is_received) {
+        return back()->with('forbidden', 'Baucer yang telah dibayar tidak boleh dipadam.');
+    } else {
+        $voucher->delete();
+        return back()->with('success', 'Baucer telah dipadam.');
+    }
+}
     public function approve(PaymentVoucher $voucher)
     {
         if ($voucher->is_received) {
@@ -129,15 +133,5 @@ class PaymentVoucherController extends Controller
         $voucher->update($attr);
 
         return back()->with('success', 'Lamparan dimuatnaik');
-    }
-
-    public function destroy(PaymentVoucher $voucher)
-    {
-        if ($voucher->is_received) {
-            return back()->with('forbidden', 'Baucer yang telah dibayar tidak boleh dipadam.');
-        } else {
-            $voucher->delete();
-            return back()->with('success', 'Baucer telah dipadam.');
-        }
     }
 }


### PR DESCRIPTION
Removed 'payee_company' and 'date' validation rules. Added 'destroy' method to handle deletion of payment vouchers.